### PR TITLE
PR2: Debug for Revit 2025-2026

### DIFF
--- a/src/Multiversion.Revit.Sample.sln
+++ b/src/Multiversion.Revit.Sample.sln
@@ -1,34 +1,37 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.6.30114.105
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36518.9 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Multiversions.Revit.Sample", "Multiversions.Revit.Sample\Multiversions.Revit.Sample.csproj", "{CE9A8A64-AB0F-4A9F-B060-474B65665B22}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug One|Any CPU = Debug One|Any CPU
-		Debug One|x64 = Debug One|x64
-		Debug One|x86 = Debug One|x86
-		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
+		Debug24-|Any CPU = Debug24-|Any CPU
+		Debug24-|x64 = Debug24-|x64
+		Debug24-|x86 = Debug24-|x86
+		Debug25+|Any CPU = Debug25+|Any CPU
+		Debug25+|x64 = Debug25+|x64
+		Debug25+|x86 = Debug25+|x86
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug One|Any CPU.ActiveCfg = Debug One|x64
-		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug One|Any CPU.Build.0 = Debug One|x64
-		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug One|x64.ActiveCfg = Debug One|x64
-		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug One|x64.Build.0 = Debug One|x64
-		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug One|x86.ActiveCfg = Debug One|x64
-		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug|Any CPU.Build.0 = Debug|x64
-		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug|x64.ActiveCfg = Debug|x64
-		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug|x64.Build.0 = Debug|x64
-		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug|x86.ActiveCfg = Debug|x64
+		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug24-|Any CPU.ActiveCfg = Debug24-|x64
+		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug24-|Any CPU.Build.0 = Debug24-|x64
+		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug24-|x64.ActiveCfg = Debug24-|x64
+		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug24-|x64.Build.0 = Debug24-|x64
+		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug24-|x86.ActiveCfg = Debug24-|x64
+		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug24-|x86.Build.0 = Debug24-|x64
+		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug25+|Any CPU.ActiveCfg = Debug25+|x64
+		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug25+|Any CPU.Build.0 = Debug25+|x64
+		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug25+|x64.ActiveCfg = Debug25+|x64
+		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug25+|x64.Build.0 = Debug25+|x64
+		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug25+|x86.ActiveCfg = Debug25+|x64
+		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Debug25+|x86.Build.0 = Debug25+|x64
 		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Release|Any CPU.ActiveCfg = Release|x64
+		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Release|Any CPU.Build.0 = Release|x64
 		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Release|x64.ActiveCfg = Release|x64
 		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Release|x64.Build.0 = Release|x64
 		{CE9A8A64-AB0F-4A9F-B060-474B65665B22}.Release|x86.ActiveCfg = Release|x64

--- a/src/Multiversions.Revit.Sample/Multiversions.Revit.Sample.csproj
+++ b/src/Multiversions.Revit.Sample/Multiversions.Revit.Sample.csproj
@@ -1,10 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+	
   <PropertyGroup>
-    <Configurations>Debug;Debug One;Release</Configurations>
+    <Configurations>Debug24-;Debug25+;Release</Configurations>
   </PropertyGroup>
 
+  <!-- Disable editorconfig -->
   <PropertyGroup>
+	<GenerateMSBuildEditorConfigFile>false</GenerateMSBuildEditorConfigFile>
+  </PropertyGroup>
+
+	<PropertyGroup>
     <!-- Please remove the targets you don't need in order
       to exclude Revit versions your add-in won't support
       use the list below for matching Revit version with .NET target
@@ -25,9 +30,19 @@
       -->
     <TargetFrameworks>net46;net47;net471;net48;net8.0-windows</TargetFrameworks>
     <RuntimeIdentifiers>win</RuntimeIdentifiers>
-    <RevitVersion Condition=" '$(RevitVersion)' == '' ">2025</RevitVersion>
+    <RevitVersion Condition=" '$(RevitVersion)' == '' ">2024</RevitVersion>
   </PropertyGroup>
-
+	
+  <!-- START: 
+                    2024
+  -->
+  <!-- DISPATCH:
+                    2018, 2019, 2020, 2021, 2025
+  -->
+  <!-- POST DISPATCH:
+	                2022, 2023, 2026
+  -->
+	
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <RevitVersion>2018</RevitVersion>
   </PropertyGroup>
@@ -40,15 +55,22 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <RevitVersion>2021</RevitVersion>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0-windows' ">
+	  <RevitVersion>2025</RevitVersion>
+  </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug One'">
-    <!-- You could debug just ONE addin version,
-         instead of building all the versions above.
-         Just put ONE target from the list above
-         e.g. if you want to debug ONLY Revit 2019,
-         put net47 below and switch to 'Debug One' configuration
-      -->
-    <TargetFrameworks>net48</TargetFrameworks>
+  <!-- Force legacy debugger required for Revit 2018 - 2024 -->	
+  <PropertyGroup Condition="'$(Configuration)'=='Debug24-'">
+    <MSBuildRemoveProperties>TargetFrameworks</MSBuildRemoveProperties>
+    <TargetFrameworks>net48;net47</TargetFrameworks>
+    <DebugEngines>{351668CC-8477-4fbf-BFE3-5F1006E4DB1F}</DebugEngines>
+  </PropertyGroup>
+
+  <!-- Enable the .NET Core debugger required for Revit 2025 & 2026 -->
+  <PropertyGroup Condition="'$(Configuration)'=='Debug25+'">
+    <MSBuildRemoveProperties>TargetFrameworks</MSBuildRemoveProperties>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
+    <UseManagedCoreDebugger>true</UseManagedCoreDebugger>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -56,9 +78,6 @@
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64</Platforms>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
-
-    <!-- Force the project to use the legacy debugger engine -->
-    <DebugEngines>{351668CC-8477-4fbf-BFE3-5F1006E4DB1F}</DebugEngines>
 
     <!-- Invert the behavior of new .csproj format - exclude files by default -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
@@ -233,10 +252,6 @@
   <Target Name="Build2023" AfterTargets="DispatchToInnerBuilds">
     <Message Importance="high" Text="*** running post-dispatch builds ***" />
     <MSBuild Projects="$(MSBuildProjectFile)" Properties="Configuration=$(Configuration); TargetFramework=net48; RevitVersion=2023"></MSBuild>
-  </Target>
-  <Target Name="Build2024" AfterTargets="DispatchToInnerBuilds">
-    <Message Importance="high" Text="*** running post-dispatch builds ***" />
-    <MSBuild Projects="$(MSBuildProjectFile)" Properties="Configuration=$(Configuration); TargetFramework=net48; RevitVersion=2024"></MSBuild>
   </Target>
   <Target Name="Build2026" AfterTargets="DispatchToInnerBuilds">
     <Message Importance="high" Text="*** running post-dispatch builds ***" />

--- a/src/Multiversions.Revit.Sample/Properties/launchSettings.json
+++ b/src/Multiversions.Revit.Sample/Properties/launchSettings.json
@@ -1,5 +1,29 @@
 {
   "profiles": {
+    "Revit 2026": {
+      "commandName": "Executable",
+      "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2026\\Revit.exe",
+      "commandLineArgs": "",
+      "use64Bit": true
+    },
+    "Revit 2025": {
+      "commandName": "Executable",
+      "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2025\\Revit.exe",
+      "commandLineArgs": "",
+      "use64Bit": true
+    },
+    "Revit 2024": {
+      "commandName": "Executable",
+      "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2024\\Revit.exe",
+      "commandLineArgs": "",
+      "use64Bit": true
+    },
+    "Revit 2023": {
+      "commandName": "Executable",
+      "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2023\\Revit.exe",
+      "commandLineArgs": "",
+      "use64Bit": true
+    },
     "Revit 2022": {
       "commandName": "Executable",
       "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2022\\Revit.exe",
@@ -27,30 +51,6 @@
     "Revit 2018": {
       "commandName": "Executable",
       "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2018\\Revit.exe",
-      "commandLineArgs": "",
-      "use64Bit": true
-    },
-    "Revit 2017": {
-      "commandName": "Executable",
-      "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2017\\Revit.exe",
-      "commandLineArgs": "",
-      "use64Bit": true
-    },
-    "Revit 2016": {
-      "commandName": "Executable",
-      "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2016\\Revit.exe",
-      "commandLineArgs": "",
-      "use64Bit": true
-    },
-    "Revit 2015": {
-      "commandName": "Executable",
-      "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2015\\Revit.exe",
-      "commandLineArgs": "",
-      "use64Bit": true
-    },
-    "Revit 2014": {
-      "commandName": "Executable",
-      "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2014\\Revit.exe",
       "commandLineArgs": "",
       "use64Bit": true
     }


### PR DESCRIPTION
Pull Request 2

On previous pull request, **PR1**, I overlooked debugging Revit 2025 & 2026...

I was not able to conditionally select a debugging engine while multi-targeting frameworks. So my work around, I replaced **Debug** & **Debug One** configurations, with **Debug24-** & **Debug25+** depending if you are launching Revit 2024 and lower or 2025 and higher.  It’s an extra step, but I can live with this for now... 

I also cleaned up launchSettings.json so it matches .csproj configuration.

Screenshot:
<img width="363" height="136" alt="image" src="https://github.com/user-attachments/assets/b5940861-9a29-4e12-a9bc-f233a10055ed" />
